### PR TITLE
Implement basic authentication and pages

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,26 @@
+const jwt = require('jsonwebtoken');
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+const authenticate = (req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Token ausente' });
+  }
+  const token = header.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Token inválido' });
+  }
+};
+
+const authorize = roles => (req, res, next) => {
+  if (!roles.includes(req.user.role)) {
+    return res.status(403).json({ message: 'Acesso negado' });
+  }
+  next();
+};
+
+module.exports = { authenticate, authorize };

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+
+const UserSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['admin', 'aluno'], default: 'aluno' }
+});
+
+UserSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  try {
+    const salt = await bcrypt.genSalt(10);
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+UserSchema.methods.comparePassword = function (candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.model('User', UserSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.3.1"
+  }
+}

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const User = require('../models/user');
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+router.post('/register', async (req, res) => {
+  try {
+    const { name, email, password, role } = req.body;
+    const existing = await User.findOne({ email });
+    if (existing) return res.status(400).json({ message: 'Usuário já existe' });
+    const user = new User({ name, email, password, role });
+    await user.save();
+    const token = jwt.sign({ id: user._id, role: user.role }, SECRET, { expiresIn: '1d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Erro no registro' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ message: 'Credenciais inválidas' });
+    const match = await user.comparePassword(password);
+    if (!match) return res.status(400).json({ message: 'Credenciais inválidas' });
+    const token = jwt.sign({ id: user._id, role: user.role }, SECRET, { expiresIn: '1d' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Erro no login' });
+  }
+});
+
+router.post('/forgot', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) return res.status(400).json({ message: 'Usuário não encontrado' });
+    user.password = password;
+    await user.save();
+    res.json({ message: 'Senha atualizada' });
+  } catch (err) {
+    res.status(500).json({ message: 'Erro na recuperação' });
+  }
+});
+
+module.exports = router;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.0.0"
+  }
+}

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        localStorage.setItem('token', data.token);
+      } else {
+        setError(data.message || 'Erro no login');
+      }
+    } catch (err) {
+      setError('Erro de conexão');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      {error && <p>{error}</p>}
+      <input
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Senha"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button type="submit">Entrar</button>
+    </form>
+  );
+}

--- a/frontend/src/pages/Auth/Register.jsx
+++ b/frontend/src/pages/Auth/Register.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+export default function Register() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('aluno');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password, role })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSuccess('Conta criada');
+      } else {
+        setError(data.message || 'Erro no cadastro');
+      }
+    } catch (err) {
+      setError('Erro de conexão');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Cadastro</h2>
+      {success && <p>{success}</p>}
+      {error && <p>{error}</p>}
+      <input
+        placeholder="Nome"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <input
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Senha"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <select value={role} onChange={e => setRole(e.target.value)}>
+        <option value="aluno">Aluno</option>
+        <option value="admin">Admin</option>
+      </select>
+      <button type="submit">Registrar</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add user model with hashed password and role
- implement auth routes for registration, login and password reset
- create JWT auth middleware with role checks
- build React login and registration pages

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977ff7ad848322af56781e9e429eae