### PR TITLE
Add professor dashboard and admin backend structures

### DIFF
--- a/backend/middleware/admin.js
+++ b/backend/middleware/admin.js
@@ -1,0 +1,7 @@
+module.exports = function (req, res, next) {
+  const user = req.user;
+  if (user && (user.role === 'admin' || user.role === 'teacher')) {
+    return next();
+  }
+  return res.status(403).json({ error: 'Acesso negado' });
+};

--- a/backend/models/payment.js
+++ b/backend/models/payment.js
@@ -1,0 +1,33 @@
+const payments = [];
+
+function generateId() {
+  return payments.length ? payments[payments.length - 1].id + 1 : 1;
+}
+
+module.exports = {
+  create(data) {
+    const payment = { id: generateId(), ...data };
+    payments.push(payment);
+    return payment;
+  },
+  findAll() {
+    return payments;
+  },
+  findById(id) {
+    return payments.find(p => p.id === Number(id));
+  },
+  update(id, data) {
+    const payment = this.findById(id);
+    if (!payment) return null;
+    Object.assign(payment, data);
+    return payment;
+  },
+  remove(id) {
+    const index = payments.findIndex(p => p.id === Number(id));
+    if (index !== -1) {
+      payments.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+};

--- a/backend/models/plan.js
+++ b/backend/models/plan.js
@@ -1,0 +1,33 @@
+const plans = [];
+
+function generateId() {
+  return plans.length ? plans[plans.length - 1].id + 1 : 1;
+}
+
+module.exports = {
+  create(data) {
+    const plan = { id: generateId(), ...data };
+    plans.push(plan);
+    return plan;
+  },
+  findAll() {
+    return plans;
+  },
+  findById(id) {
+    return plans.find(p => p.id === Number(id));
+  },
+  update(id, data) {
+    const plan = this.findById(id);
+    if (!plan) return null;
+    Object.assign(plan, data);
+    return plan;
+  },
+  remove(id) {
+    const index = plans.findIndex(p => p.id === Number(id));
+    if (index !== -1) {
+      plans.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+};

--- a/backend/models/theme.js
+++ b/backend/models/theme.js
@@ -1,0 +1,33 @@
+const themes = [];
+
+function generateId() {
+  return themes.length ? themes[themes.length - 1].id + 1 : 1;
+}
+
+module.exports = {
+  create(data) {
+    const theme = { id: generateId(), ...data };
+    themes.push(theme);
+    return theme;
+  },
+  findAll() {
+    return themes;
+  },
+  findById(id) {
+    return themes.find(t => t.id === Number(id));
+  },
+  update(id, data) {
+    const theme = this.findById(id);
+    if (!theme) return null;
+    Object.assign(theme, data);
+    return theme;
+  },
+  remove(id) {
+    const index = themes.findIndex(t => t.id === Number(id));
+    if (index !== -1) {
+      themes.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+};

--- a/backend/routes/teacher.js
+++ b/backend/routes/teacher.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const router = express.Router();
+const admin = require('../middleware/admin');
+const service = require('../services/teacherService');
+
+// all routes below require admin/teacher role
+router.use(admin);
+
+// Theme CRUD
+router.get('/themes', (req, res) => {
+  res.json(service.listThemes());
+});
+
+router.post('/themes', (req, res) => {
+  const theme = service.createTheme(req.body);
+  res.status(201).json(theme);
+});
+
+router.put('/themes/:id', (req, res) => {
+  const theme = service.updateTheme(req.params.id, req.body);
+  if (!theme) return res.status(404).json({ error: 'Tema não encontrado' });
+  res.json(theme);
+});
+
+router.delete('/themes/:id', (req, res) => {
+  const success = service.removeTheme(req.params.id);
+  res.json({ success });
+});
+
+// Student management
+router.get('/students', (req, res) => {
+  res.json(service.listStudents());
+});
+
+router.post('/students', (req, res) => {
+  const student = service.addStudent(req.body);
+  res.status(201).json(student);
+});
+
+router.delete('/students/:id', (req, res) => {
+  const success = service.removeStudent(req.params.id);
+  res.json({ success });
+});
+
+// Corrections
+router.get('/corrections', (req, res) => {
+  res.json(service.listCorrections());
+});
+
+router.post('/corrections', (req, res) => {
+  const correction = service.addCorrection(req.body);
+  res.status(201).json(correction);
+});
+
+module.exports = router;

--- a/backend/services/teacherService.js
+++ b/backend/services/teacherService.js
@@ -1,0 +1,50 @@
+const Theme = require('../models/theme');
+const Plan = require('../models/plan');
+const Payment = require('../models/payment');
+
+const students = [];
+const corrections = [];
+
+module.exports = {
+  // Theme operations
+  listThemes: () => Theme.findAll(),
+  createTheme: data => Theme.create(data),
+  updateTheme: (id, data) => Theme.update(id, data),
+  removeTheme: id => Theme.remove(id),
+
+  // Plan operations
+  listPlans: () => Plan.findAll(),
+  createPlan: data => Plan.create(data),
+  updatePlan: (id, data) => Plan.update(id, data),
+  removePlan: id => Plan.remove(id),
+
+  // Payment operations
+  listPayments: () => Payment.findAll(),
+  createPayment: data => Payment.create(data),
+  updatePayment: (id, data) => Payment.update(id, data),
+  removePayment: id => Payment.remove(id),
+
+  // Student operations
+  listStudents: () => students,
+  addStudent: data => {
+    const student = { id: students.length ? students[students.length - 1].id + 1 : 1, ...data };
+    students.push(student);
+    return student;
+  },
+  removeStudent: id => {
+    const index = students.findIndex(s => s.id === Number(id));
+    if (index !== -1) {
+      students.splice(index, 1);
+      return true;
+    }
+    return false;
+  },
+
+  // Correction operations
+  listCorrections: () => corrections,
+  addCorrection: data => {
+    const correction = { id: corrections.length ? corrections[corrections.length - 1].id + 1 : 1, ...data };
+    corrections.push(correction);
+    return correction;
+  }
+};

--- a/frontend/src/pages/ProfessorDashboard/EssayList.jsx
+++ b/frontend/src/pages/ProfessorDashboard/EssayList.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function EssayList({ essays }) {
+  return (
+    <div>
+      <h2>Redações</h2>
+      <ul>
+        {essays.map(essay => (
+          <li key={essay.id}>{essay.title} - {essay.student}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfessorDashboard/Stats.jsx
+++ b/frontend/src/pages/ProfessorDashboard/Stats.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function Stats({ stats }) {
+  return (
+    <div>
+      <h2>Estatísticas</h2>
+      <ul>
+        <li>Total de alunos: {stats.students}</li>
+        <li>Total de redações: {stats.essays}</li>
+        <li>Correções pendentes: {stats.pendingCorrections}</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfessorDashboard/StudentList.jsx
+++ b/frontend/src/pages/ProfessorDashboard/StudentList.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function StudentList({ students }) {
+  return (
+    <div>
+      <h2>Alunos</h2>
+      <ul>
+        {students.map(student => (
+          <li key={student.id}>{student.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfessorDashboard/index.jsx
+++ b/frontend/src/pages/ProfessorDashboard/index.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import Stats from './Stats';
+import EssayList from './EssayList';
+import StudentList from './StudentList';
+
+export default function ProfessorDashboard() {
+  const [stats, setStats] = useState({ students: 0, essays: 0, pendingCorrections: 0 });
+  const [essays, setEssays] = useState([]);
+  const [students, setStudents] = useState([]);
+
+  useEffect(() => {
+    // Placeholder for loading data from backend
+    setStats({ students: 3, essays: 5, pendingCorrections: 2 });
+    setEssays([
+      { id: 1, title: 'Redação 1', student: 'Aluno A' },
+      { id: 2, title: 'Redação 2', student: 'Aluno B' }
+    ]);
+    setStudents([
+      { id: 1, name: 'Aluno A' },
+      { id: 2, name: 'Aluno B' }
+    ]);
+  }, []);
+
+  return (
+    <div>
+      <h1>Painel do Professor</h1>
+      <Stats stats={stats} />
+      <EssayList essays={essays} />
+      <StudentList students={students} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build professor dashboard React page with statistics, essays, and students
- implement teacher routes with CRUD for themes, student management, and corrections
- add in-memory models for themes, plans, payments and service layer
- protect teacher routes with admin middleware

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68977ff9ab388322bd7c12f42e9b04b5