### PR TITLE
Add basic payment and subscription scaffolding

### DIFF
--- a/backend/models/subscription.js
+++ b/backend/models/subscription.js
@@ -1,0 +1,11 @@
+class Subscription {
+  constructor({ userId, plan, startDate = new Date(), endDate = null, status = 'active' }) {
+    this.userId = userId;
+    this.plan = plan;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.status = status;
+  }
+}
+
+module.exports = Subscription;

--- a/backend/models/transaction.js
+++ b/backend/models/transaction.js
@@ -1,0 +1,11 @@
+class Transaction {
+  constructor({ userId, subscriptionId, amount, status = 'pending', createdAt = new Date() }) {
+    this.userId = userId;
+    this.subscriptionId = subscriptionId;
+    this.amount = amount;
+    this.status = status;
+    this.createdAt = createdAt;
+  }
+}
+
+module.exports = Transaction;

--- a/backend/services/payment/index.js
+++ b/backend/services/payment/index.js
@@ -1,0 +1,28 @@
+class PaymentGateway {
+  constructor(provider) {
+    this.provider = provider;
+  }
+
+  /**
+   * Process a payment using the configured provider.
+   * @param {Object} data - payment data
+   * @param {Function} onSuccess - callback on success
+   * @param {Function} onFailure - callback on failure
+   */
+  processPayment(data, onSuccess, onFailure) {
+    // TODO: integrate provider SDK (PagSeguro, Stripe, etc.)
+    try {
+      // Simulate payment processing
+      const result = { status: 'success', provider: this.provider, data };
+      if (typeof onSuccess === 'function') {
+        onSuccess(result);
+      }
+    } catch (err) {
+      if (typeof onFailure === 'function') {
+        onFailure(err);
+      }
+    }
+  }
+}
+
+module.exports = PaymentGateway;

--- a/backend/services/planRestrictions.js
+++ b/backend/services/planRestrictions.js
@@ -1,0 +1,16 @@
+const PLAN_LIMITS = {
+  free: { submissions: 1, corrections: 0 },
+  premium: { submissions: Infinity, corrections: Infinity }
+};
+
+function canSubmit(plan, submissionsCount) {
+  const limits = PLAN_LIMITS[plan] || PLAN_LIMITS.free;
+  return submissionsCount < limits.submissions;
+}
+
+function canRequestCorrection(plan, correctionsCount) {
+  const limits = PLAN_LIMITS[plan] || PLAN_LIMITS.free;
+  return correctionsCount < limits.corrections;
+}
+
+module.exports = { PLAN_LIMITS, canSubmit, canRequestCorrection };

--- a/frontend/src/pages/AlunoDashboard/Planos/index.jsx
+++ b/frontend/src/pages/AlunoDashboard/Planos/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Planos() {
+  return (
+    <div>
+      <h1>Planos de Assinatura</h1>
+      {/* TODO: Implement subscription form and history list */}
+    </div>
+  );
+}
+
+export default Planos;


### PR DESCRIPTION
## Summary
- scaffold payment gateway service with success/failure callbacks
- add subscription and transaction models
- add plan restriction helpers
- add placeholder Planos page for subscription/history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68978012add4832283e4673300ccf075