### PR TITLE
docs: add frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,20 @@
+# Frontend
+
+## Instalação
+1. Certifique-se de estar no diretório `frontend`.
+2. Execute `npm install` para instalar as dependências.
+
+## Uso
+1. Após a instalação, execute `npm start` para iniciar a aplicação.
+
+## Scripts Disponíveis
+- `npm start`: inicia a aplicação.
+- `npm test`: executa a suíte de testes (não há testes configurados).
+
+## Dependências
+- react ^18.2.0
+- react-dom ^18.2.0
+- pdfjs-dist ^3.6.172
+- mammoth ^1.4.21
+- pdf-lib ^1.17.1
+- styled-components ^6.1.19


### PR DESCRIPTION
## Summary
- document frontend setup instructions
- list available scripts and dependencies

## Testing
- `cd frontend && npm install`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a951a96c8322a25b22ec6e7f2eea